### PR TITLE
Added Decoded:Legal to the Onion List

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,11 @@ Pull requests for the SecureDrop list will be accepted only for entries of the f
 * http://forums.kkkkkkkkkk63ava6.onion/ forums
 * http://kkkkkkkkkk63ava6.onion/wiki/Forcing_.onion_on_Whonix.org index of onion sites
   * also https://www.whonix.org/wiki/Forcing_.onion_on_Whonix.org
-  
+
+## Decoded:Legal
+* http://expvqqiv2z5ekf47.onion/ UK Law Firm
+  * https://decodedlegal.com
+
 ----
 
 # SecureDrop sites


### PR DESCRIPTION
Decoded:Legal are a specialist internet/telco/tech law firm in the UK with a .onion