### PR TITLE
Adding "communities and organisations"  category

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ See also https://securedrop.org/directory - but this page seeks to be more inclu
 * http://strngbxhwyuu37a3.onion/
 * http://projects.newyorker.com/strongbox/
 
+
 ## OKO Press (Polish investigative journalist organisation)
  * http://p6vbgbn7ggutkt3i.onion/
  * https://oko.press/
@@ -281,6 +282,10 @@ TBD
 ## Brmlab, Prague Hackerspace
   * http://pmwdzvbyvnmwobk5.onion/ onion site
   * https://brmlab.cz/start clearweb site
+
+## XNet activism anticorruption leak site
+ * http://ztjn5gcdsqeqzmw4.onion/
+ * https://xnet-x.net/en/xnetleaks/
 
 ----
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,10 @@ See also https://securedrop.org/directory - but this page seeks to be more inclu
 * http://qn4qfeeslglmwxgb.onion/
 * https://lucyparsonslabs.com/securedrop
 
+## Mexico Leaks
+ * http://kjpkmlafh2ra57wz.onion/
+ * https://mexicoleaks.mx/
+
 ## NEOSleaks
 * http://udrciweihl4qe63p.onion/
 * https://neos.eu/leaks/

--- a/README.md
+++ b/README.md
@@ -256,6 +256,14 @@ TBD
 
 ----
 
+# Communities and organisations
+
+## Brmlab, Prague Hackerspace
+  * http://pmwdzvbyvnmwobk5.onion/ onion site
+  * https://brmlab.cz/start clearweb site
+
+----
+
 # Submission Notes
 
 - **NO MORE THAN 1 SITE PER REQUEST WILL BE ACCEPTED**

--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ See also https://securedrop.org/directory - but this page seeks to be more inclu
 * http://ad2ztmbv5vmbj7ic.onion
 * https://securedrop.cbc.ca/
 
+## Curiamo La Corruzione (Anticorruption reporting for Italian government health services)
+ * http://evz2fbu64s3lzhsi.onion/
+ * https://segnalazioni.curiamolacorruzione.it/
+
 ## CPJ / Committee to Protect Journalists
 * http://2x2hb5ykeu4qlxqe.onion/
 * https://cpj.org/blog/2016/05/how-securedrop-helps-cpj-protect-journalists.php

--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ See also https://securedrop.org/directory - but this page seeks to be more inclu
 * http://bl2uafhsjrtc2gf4.onion/
 * https://berlinleaks.org
 
+## Bezkorupce.cz / Czech Anticorruption reporting site
+ * http://iopx5pchfdldldwp.onion/
+ * https://secure.bezkorupce.cz/
+
 ## CBC / Canadian Broadcasting Corporation
 * http://ad2ztmbv5vmbj7ic.onion
 * https://securedrop.cbc.ca/

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Sites that use https://securedrop.org/
 
 See also https://securedrop.org/directory - but this page seeks to be more inclusive.
 
-## Afrileaks 
+## Afrileaks
  * http://wcnueib4qrsm544n.onion/
  * https://www.afrileaks.org/
 
@@ -203,6 +203,10 @@ See also https://securedrop.org/directory - but this page seeks to be more inclu
 ## Sourcesure.eu / Leak site for France and Belgium
  * http://hgowugmgkiv2wxs5.onion/
  * https://www.sourcesure.eu/
+
+## Transparency International Italy / anticorruption reporting site
+ * http://fkut2p37apcg6l7f.onion/
+ * https://allertaanticorruzione.transparency.it/servizio-alac/
 
 ## VG / Verdens Gang
 * http://vgnettwin5lyl4yr.onion/

--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ Sites that use https://securedrop.org/
 
 See also https://securedrop.org/directory - but this page seeks to be more inclusive.
 
+## Afrileaks 
+ * http://wcnueib4qrsm544n.onion/
+ * https://www.afrileaks.org/
+
 ## Aftenposten
 * http://da5nr4lx4djdrsj7.onion/
 * https://www.aftenposten.no/securedrop/

--- a/README.md
+++ b/README.md
@@ -159,6 +159,10 @@ See also https://securedrop.org/directory - but this page seeks to be more inclu
 * http://strngbxhwyuu37a3.onion/
 * http://projects.newyorker.com/strongbox/
 
+## OKO Press (Polish investigative journalist organisation)
+ * http://p6vbgbn7ggutkt3i.onion/
+ * https://oko.press/
+
 ## POGO / Project On Government Oversight
 * http://dqeasamlf3jld2kz.onion/
 * https://securedrop.pogo.org/

--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ See also https://securedrop.org/directory - but this page seeks to be more inclu
 * http://2x2hb5ykeu4qlxqe.onion/
 * https://cpj.org/blog/2016/05/how-securedrop-helps-cpj-protect-journalists.php
 
+## Edison Energy / Italy energy company corporate whistleblowing
+ * http://754hkfmiyumu5xlc.onion/
+ * https://segnalazioni.edison.it/
+
 ## ExposeFacts
 * http://znig4bc5rlwyj4mz.onion/
 * https://exposefacts.org

--- a/README.md
+++ b/README.md
@@ -187,6 +187,10 @@ See also https://securedrop.org/directory - but this page seeks to be more inclu
 * http://vbmwh445kf3fs2v4.onion/
 * https://www.washingtonpost.com/securedrop/
 
+## Wildleaks / Elephant Action League
+* https://www.wildleaks.org/the-technology/
+* http://ppdz5djzpo3w5k2z.onion/
+
 ----
 
 # SecureDrop Sites for Individual Journalists

--- a/README.md
+++ b/README.md
@@ -196,6 +196,10 @@ See also https://securedrop.org/directory - but this page seeks to be more inclu
 * http://hpjw636qnt5avq62.onion/
 * https://securedrop.radio24syv.dk
 
+## Sourcesure.eu / Leak site for France and Belgium
+ * http://hgowugmgkiv2wxs5.onion/
+ * https://www.sourcesure.eu/
+
 ## VG / Verdens Gang
 * http://vgnettwin5lyl4yr.onion/
 * https://securedrop.vg.no/


### PR DESCRIPTION
The list is quite rich already, but there are some onion sites, which
don’t fall under the current categories.

I propose a “community and organisation” categories for associations,
organised communities.

I have added a hackerspace in Prague (both their clearweb and .onion
site) to this PR as an example of one such organisation.

I have including first-party "proof" url.