### PR TITLE
Addition of Hungarian Atlatszo.hu leaks site

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,10 @@ See also https://securedrop.org/directory
 ## ALAT / Allerta AntiCorruzione, Italian Whistleblowing
 * http://fkut2p37apcg6l7f.onion/
   * https://allertaanticorruzione.transparency.it/servizio-alac/
+  
+## Atlatszo MagyarLeaks / Hungarian Investigative Journalism Leaks
+* http://ak2uqfavwgmjrvtu.onion/
+  * https://atlatszo.hu/magyarleaks/
 
 ## Curiamo La Corruzione / Italian Government Health Whistleblowing
 * http://evz2fbu64s3lzhsi.onion/


### PR DESCRIPTION
Addition of  Hungarian Atlatszo.hu leaks site, using Global Leaks platform.

Including first-party "proof" url.