### PR TITLE
Addition of Dutch Publeaks.nl Whistleblowing site

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,10 @@ See also https://securedrop.org/directory
 ## ALAT / Allerta AntiCorruzione, Italian Whistleblowing
 * http://fkut2p37apcg6l7f.onion/
   * https://allertaanticorruzione.transparency.it/servizio-alac/
+  
+## Atlatszo MagyarLeaks / Hungarian Investigative Journalism Leaks
+* http://ak2uqfavwgmjrvtu.onion/
+  * https://atlatszo.hu/magyarleaks/
 
 ## Curiamo La Corruzione / Italian Government Health Whistleblowing
 * http://evz2fbu64s3lzhsi.onion/

--- a/README.md
+++ b/README.md
@@ -252,6 +252,10 @@ See also https://securedrop.org/directory
 ## OKO.press / Polish Journalist
 * http://p6vbgbn7ggutkt3i.onion/
   * https://oko.press/
+  
+## Publeaks.nl / Dutch Whistleblowing
+* http://5karyquenden4d6k.onion/
+ * https://www.publeaks.nl/
 
 ## Sourcesure.eu / France & Belgium Whistleblowing
 * http://hgowugmgkiv2wxs5.onion/


### PR DESCRIPTION
Addition of Dutch Publeaks.nl Whistleblowing site, managed by multiple media organisations, using Global Leaks platform.

Including first-party "proof" url.